### PR TITLE
Run permission check before args length check

### DIFF
--- a/src/main/java/com/kabryxis/attributehider/AttributeHider.java
+++ b/src/main/java/com/kabryxis/attributehider/AttributeHider.java
@@ -39,15 +39,15 @@ public class AttributeHider extends JavaPlugin implements Listener {
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 		if(cmd.getName().equalsIgnoreCase("attributehider")) {
-			if(args.length == 1 && args[0].equalsIgnoreCase("reload")) {
-				if(!sender.hasPermission(getConfig().getString("command.permission"))) {
-					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', getConfig().getString("command.no-permission")));
-					return true;
-				}
-				reloadConfig();
-				sender.sendMessage(ChatColor.translateAlternateColorCodes('&', getConfig().getString("command.reloaded")));
-				remover.setup();
+			if(!sender.hasPermission(getConfig().getString("command.permission"))) {
+				sender.sendMessage(ChatColor.translateAlternateColorCodes('&', getConfig().getString("command.no-permission")));
 				return true;
+			}
+				if(args.length == 1 && args[0].equalsIgnoreCase("reload")) {
+					reloadConfig();
+					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', getConfig().getString("command.reloaded")));
+					remover.setup();
+					return true;
 			}
 		}
 		return false;

--- a/src/main/java/com/kabryxis/attributehider/AttributeHider.java
+++ b/src/main/java/com/kabryxis/attributehider/AttributeHider.java
@@ -43,11 +43,11 @@ public class AttributeHider extends JavaPlugin implements Listener {
 				sender.sendMessage(ChatColor.translateAlternateColorCodes('&', getConfig().getString("command.no-permission")));
 				return true;
 			}
-				if(args.length == 1 && args[0].equalsIgnoreCase("reload")) {
-					reloadConfig();
-					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', getConfig().getString("command.reloaded")));
-					remover.setup();
-					return true;
+			if(args.length == 1 && args[0].equalsIgnoreCase("reload")) {
+				reloadConfig();
+				sender.sendMessage(ChatColor.translateAlternateColorCodes('&', getConfig().getString("command.reloaded")));
+				remover.setup();
+				return true;
 			}
 		}
 		return false;


### PR DESCRIPTION
Running args length check before causes players who don't have the main permission to receive the "/ah reload" message. This pull request should prevent this from happening.